### PR TITLE
Additional nullguards for Layer after the user gets logout

### DIFF
--- a/src/mixins/client-conversations.js
+++ b/src/mixins/client-conversations.js
@@ -204,7 +204,8 @@ module.exports = {
       if (!Conversation.isValidId(id)) {
         id = Conversation.prefixUUID + id;
       }
-      if (this._models.conversations[id]) {
+      // it might be called after user's logout
+      if (this._models && this._models.conversations && this._models.conversations[id]) {
         return this._models.conversations[id];
       } else if (canLoad) {
         return Conversation.load(id, this);

--- a/src/mixins/client-conversations.js
+++ b/src/mixins/client-conversations.js
@@ -205,6 +205,7 @@ module.exports = {
         id = Conversation.prefixUUID + id;
       }
       // it might be called after user's logout
+      // undo this change with CORE-1674
       if (this._models && this._models.conversations && this._models.conversations[id]) {
         return this._models.conversations[id];
       } else if (canLoad) {

--- a/src/mixins/client-queries.js
+++ b/src/mixins/client-queries.js
@@ -117,6 +117,7 @@ module.exports = {
      */
     _addQuery(query) {
       // it might be called after user's logout
+      // undo this change with CORE-1674
       if (this._models && this._models.queries) {
         this._models.queries[query.id] = query;
       }

--- a/src/mixins/client-queries.js
+++ b/src/mixins/client-queries.js
@@ -116,7 +116,10 @@ module.exports = {
      * @param  {layer.Query} query
      */
     _addQuery(query) {
-      this._models.queries[query.id] = query;
+      // it might be called after user's logout
+      if (this._models && this._models.queries) {
+        this._models.queries[query.id] = query;
+      }
     },
 
     /**


### PR DESCRIPTION
https://chimebank.atlassian.net/browse/CORE-1556

These two places get called after the user's logout on ChatBot, and sometimes crash the app because the layer client is missing some fields. It's because somehow it tries to render chatbot one more time when the user sends 'logout' action on Lockscreen. These null guards along with simple changes in our codebase fix the issue.